### PR TITLE
Fixed action version for a version that runs on node 16 and not node 12

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
     using: composite
     steps:
         - name: Setup Node.js
-          uses: actions/setup-node@v2
+          uses: actions/setup-node@v3
           with:
               node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -15,7 +15,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup Node.js
               uses: ./.github/actions/setup-node
@@ -41,7 +41,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup Node.js
               uses: ./.github/actions/setup-node

--- a/.github/workflows/on-push-workflow.yml
+++ b/.github/workflows/on-push-workflow.yml
@@ -38,13 +38,13 @@ jobs:
       steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
     
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description

There was an issue with the node version for some of the actions used in the workflow.

## Changes Made

Changed the version of checkout, setup-node and configure-aws-credentials action that runs on node 16.

## Related Issue
https://github.com/Monitoring-Mtl/Serverless-API/issues/86

## Checklist

- [ ] I have tested these changes locally.
- [ ] I have included necessary documentation updates (if applicable).
- [x ] My code follows the project's coding standards.
- [ ] All existing tests are passing.
- [ ] I have added new tests (if new features or changes warrant them).
