### PR TITLE
Fix du lien vers doc swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ _Vous trouverez ci-bas un exemple de la procédure pour installer le projet loca
 <!-- EXAMPLES D'UTILISATION -->
 ## Utilisation
 
-Pour utiliser les endpoints de l'application visiter [swagger](https://monitoring-mtl.github.io/Swagger-github-pages/) </br>
+Pour utiliser les endpoints de l'application visiter [swagger](https://swagger.monitoring-mtl.info/) </br>
 Pour contribuer ou mettre a jour la documentation Swagger, voir ce [repertoire](https://github.com/Monitoring-Mtl/Swagger-github-pages)
 
 ### Rapport de couverture de tests


### PR DESCRIPTION
## Description

Le lien vers la documentation swagger était obsolète. Il a été corrigé.

## Changes Made

Le lien vers la documentation swagger a été modifié.